### PR TITLE
細かいバグ修正

### DIFF
--- a/src/components/Drawer/HeaderDrawer.tsx
+++ b/src/components/Drawer/HeaderDrawer.tsx
@@ -28,11 +28,11 @@ export const HeaderDrawer: FC<Props> = ({ links }) => {
       {isOpen && (
         <>
           <div
-            className="fixed w-full h-screen z-30 bg-gray-800 top-0 left-0 opacity-50"
+            className="fixed w-full h-screen z-40 bg-gray-800 top-0 left-0 opacity-50"
             onClick={onClose}
           />
 
-          <div className="fixed z-40 bg-white top-0 right-0 w-9/12 sm:w-1/3 h-screen">
+          <div className="fixed z-50 bg-white top-0 right-0 w-9/12 sm:w-1/3 h-screen">
             <div className="flex justify-between p-2">
               <Link href="/#top" passHref>
                 <Image

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -29,7 +29,7 @@ const links = [
 
 export const Header: FC = () => {
   return (
-    <header className="fixed w-full h-12 top-0 p-2 md:px-10 flex justify-between flex-wrap bg-white drop-shadow bg-white/[.7]">
+    <header className="fixed w-full z-30 h-12 top-0 p-2 md:px-10 flex justify-between flex-wrap bg-white drop-shadow bg-white/[.7]">
       <Link href="/#top" passHref>
         <Image
           src="/images/icon/sekiyan372.png"

--- a/src/sections/topPage/Product.tsx
+++ b/src/sections/topPage/Product.tsx
@@ -87,7 +87,9 @@ export const Product = forwardRef<HTMLElement>((_, ref) => {
             key={join.title}
             className="inline-block border-b border-jade m-2 text-xs text-jade sm:text-base cursor-pointer hover:opacity-60"
           >
-            <a href={join.url}>{join.title}</a>
+            <a href={join.url} target="_blank" rel="noreferrer">
+              {join.title}
+            </a>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## 内容
- プロダクトの画像がヘッダーの上に浮き出る問題を修正
- プロダクトのJoinのリンクをタブで開くようにする